### PR TITLE
Fuzz Strategy Distribution Calculation

### DIFF
--- a/src/appengine/handlers/cron/fuzz_strategy_selection.py
+++ b/src/appengine/handlers/cron/fuzz_strategy_selection.py
@@ -114,6 +114,8 @@ def _upload_fuzz_strategy_weights(client):
     curr_strategy.strategy_name = str(row['strategy'])
     curr_strategy.strategy_probability = float(row['bandit_weight'])
     strategy_data.append(curr_strategy)
+  ndb.delete_multi(
+      data_types.FuzzStrategyProbability.query().fetch(keys_only=True))
   ndb.put_multi(strategy_data)
 
 

--- a/src/appengine/handlers/cron/fuzz_strategy_selection.py
+++ b/src/appengine/handlers/cron/fuzz_strategy_selection.py
@@ -112,7 +112,6 @@ def _upload_fuzz_strategy_weights(client):
   for row in data:
     curr_strategy = data_types.FuzzStrategyProbability()
     curr_strategy.strategy_name = str(row['strategy'])
-    curr_strategy.strategy_count = int(row['strategy_count'])
     curr_strategy.strategy_probability = float(row['bandit_weight'])
     strategy_data.append(curr_strategy)
   ndb.put_multi(strategy_data)

--- a/src/python/datastore/data_types.py
+++ b/src/python/datastore/data_types.py
@@ -1114,7 +1114,6 @@ class FuzzStrategyProbability(Model):
 
   Calculated using a softmax multi-armed bandit probability model."""
   strategy_name = ndb.StringProperty()
-  strategy_count = ndb.IntegerProperty()
   strategy_probability = ndb.FloatProperty()
 
 

--- a/src/python/tests/appengine/handlers/cron/fuzz_strategy_selection_test.py
+++ b/src/python/tests/appengine/handlers/cron/fuzz_strategy_selection_test.py
@@ -56,19 +56,3 @@ class TestFuzzStrategySelection(unittest.TestCase):
         data_types.FuzzStrategyProbability.strategy_name ==
         'max len,ml rnn,dict,').get()
     self.assertEqual(row3.strategy_probability, 0.03471989092623837)
-
-  def test_strategy_counts(self):
-    """Unit tests for strategy count updates."""
-    fuzz_strategy_selection._upload_fuzz_strategy_weights(None)
-    row1 = data_types.FuzzStrategyProbability.query(
-        data_types.FuzzStrategyProbability.strategy_name ==
-        'ml rnn,fork,').get()
-    self.assertEqual(row1.strategy_count, 128988)
-    row2 = data_types.FuzzStrategyProbability.query(
-        data_types.FuzzStrategyProbability.strategy_name ==
-        'ml rnn,fork,subset,').get()
-    self.assertEqual(row2.strategy_count, 127312)
-    row3 = data_types.FuzzStrategyProbability.query(
-        data_types.FuzzStrategyProbability.strategy_name ==
-        'max len,ml rnn,dict,').get()
-    self.assertEqual(row3.strategy_count, 1193)

--- a/src/python/tests/appengine/handlers/cron/fuzz_strategy_selection_test.py
+++ b/src/python/tests/appengine/handlers/cron/fuzz_strategy_selection_test.py
@@ -56,3 +56,12 @@ class TestFuzzStrategySelection(unittest.TestCase):
         data_types.FuzzStrategyProbability.strategy_name ==
         'max len,ml rnn,dict,').get()
     self.assertEqual(row3.strategy_probability, 0.03471989092623837)
+
+  def test_delete_from_table(self):
+    """Unit test to check whether entries are properly deleted
+    before being updated."""
+    fuzz_strategy_selection._upload_fuzz_strategy_weights(None)
+    count1 = data_types.FuzzStrategyProbability.query().count()
+    fuzz_strategy_selection._upload_fuzz_strategy_weights(None)
+    count2 = data_types.FuzzStrategyProbability.query().count()
+    self.assertEqual(count1, count2)


### PR DESCRIPTION
Got rid of strategy count in the ndb table and updated code so that previous strategy probability entries are deleted upon update.